### PR TITLE
Setup repo to build .whl for pypi and conda-forge

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,21 @@
+include *.md
+include pyproject.toml
+include package.json
+include ts*.json
+include yarn.lock
+
+graft jupyterlab-spreadsheet/labextension
+
+# Javascript files
+graft src
+graft style
+prune **/node_modules
+prune lib
+prune binder
+
+# Patterns to exclude from any directory
+global-exclude *~
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude .git
+global-exclude .ipynb_checkpoints

--- a/package.json
+++ b/package.json
@@ -4,11 +4,33 @@
   "description": "Adds a spreadsheet viewer to JupyterLab",
   "main": "lib/index.js",
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "outputDir": "jupyterlab-spreadsheet/labextension"
   },
   "scripts": {
-    "build": "tsc",
-    "lint": "eslint --ext .ts src/**"
+    "build": "jlpm build:lib && jlpm build:labextension:dev",
+    "build:prod": "jlpm clean && jlpm build:lib && jlpm build:labextension",
+    "build:labextension": "jupyter labextension build .",
+    "build:labextension:dev": "jupyter labextension build --development True .",
+    "build:lib": "tsc",
+    "clean": "jlpm clean:lib",
+    "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+    "clean:lintcache": "rimraf .eslintcache .stylelintcache",
+    "clean:labextension": "rimraf {{ cookiecutter.python_name }}/labextension",
+    "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
+    "eslint": "jlpm eslint:check --fix",
+    "eslint:check": "eslint . --cache --ext .ts,.tsx",
+    "install:extension": "jlpm build",
+    "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
+    "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
+    "prettier": "jlpm prettier:base --write --list-different",
+    "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+    "prettier:check": "jlpm prettier:base --check",
+    "stylelint": "jlpm stylelint:check --fix",
+    "stylelint:check": "stylelint --cache \"style/**/*.css\"",
+    "watch": "run-p watch:src watch:labextension",
+    "watch:src": "tsc -w",
+    "watch:labextension": "jupyter labextension watch ."
   },
   "keywords": [
     "jupyterlab-extension",
@@ -20,7 +42,11 @@
     "style/*.css"
   ],
   "repository": "https://github.com/quigleyj97/jupyterlab-spreadsheet",
-  "author": "Joe Quigley",
+  "homepage": "https://github.com/quigleyj97/jupyterlab-spreadsheet",
+  "author": {
+    "name": "Joe Quigley",
+    "email": "quigley.joseph@outlook.com"
+  },
   "license": "BSD-3-Clause",
   "private": false,
   "dependencies": {
@@ -38,6 +64,7 @@
     "xlsx": "^0.17.0"
   },
   "devDependencies": {
+    "@jupyterlab/builder": "^3.3.2",
     "@types/slickgrid": "^2.1.27",
     "@typescript-eslint/eslint-plugin": "^4.28.0",
     "@typescript-eslint/parser": "^4.28.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["jupyter_packaging~=0.10,<2", "jupyterlab~=3.1"]
+build-backend = "jupyter_packaging.build_api"
+
+[tool.jupyter-packaging.options]
+skip-if-exists = ["jupyterlab-spreadsheet/labextension/static/style.js"]
+ensured-targets = ["jupyterlab-spreadsheet/labextension/static/style.js", "jupyterlab-spreadsheet/labextension/package.json"]
+
+[tool.jupyter-packaging.builder]
+factory = "jupyter_packaging.npm_builder"
+
+[tool.jupyter-packaging.build-args]
+build_cmd = "build:prod"
+npm = ["jlpm"]
+
+[tool.check-manifest]
+ignore = ["jupyterlab-spreadsheet/labextension/**", "yarn.lock", ".*", "package-lock.json"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,95 @@
+"""
+jupyterlab-spreadsheet setup
+"""
+import json
+import sys
+from pathlib import Path
+
+import setuptools
+
+HERE = Path(__file__).parent.resolve()
+
+# Get the package info from package.json
+pkg_json = json.loads((HERE / "package.json").read_bytes())
+
+# The name of the project
+name = "jupyterlab-spreadsheet"
+
+lab_path = (HERE / pkg_json["jupyterlab"]["outputDir"])
+
+# Representative files that should exist after a successful build
+ensured_targets = [
+    str(lab_path / "package.json"),
+    str(lab_path / "static/style.js")
+]
+
+labext_name = pkg_json["name"]
+
+data_files_spec = [
+    ("share/jupyter/labextensions/%s" % labext_name, str(lab_path.relative_to(HERE)), "**"),
+    ("share/jupyter/labextensions/%s" % labext_name, str("."), "install.json")
+]
+
+long_description = (HERE / "README.md").read_text()
+
+version = (
+    pkg_json["version"]
+    .replace("-alpha.", "a")
+    .replace("-beta.", "b")
+    .replace("-rc.", "rc")
+) 
+
+setup_args = dict(
+    name=name,
+    version=version,
+    url=pkg_json["homepage"],
+    author=pkg_json["author"]["name"],
+    author_email=pkg_json["author"]["email"],
+    description=pkg_json["description"],
+    license=pkg_json["license"],
+    license_file="LICENSE",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    packages=setuptools.find_packages(),
+    install_requires=[],
+    zip_safe=False,
+    include_package_data=True,
+    python_requires=">=3.7",
+    platforms="Linux, Mac OS X, Windows",
+    keywords=["Jupyter", "JupyterLab", "JupyterLab3"],
+    classifiers=[
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Framework :: Jupyter",
+        "Framework :: Jupyter :: JupyterLab",
+        "Framework :: Jupyter :: JupyterLab :: 3",
+        "Framework :: Jupyter :: JupyterLab :: Extensions",
+        "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+    ],
+)
+
+try:
+    from jupyter_packaging import (
+        wrap_installers,
+        npm_builder,
+        get_data_files
+    )
+    post_develop = npm_builder(
+        build_cmd="install:extension", source_dir="src", build_dir=lab_path
+    )
+    setup_args["cmdclass"] = wrap_installers(post_develop=post_develop, ensured_targets=ensured_targets)
+    setup_args["data_files"] = get_data_files(data_files_spec)
+except ImportError as e:
+    import logging
+    logging.basicConfig(format="%(levelname)s: %(message)s")
+    logging.warning("Build tool `jupyter-packaging` is missing. Install it with pip or conda.")
+    if not ("--name" in sys.argv or "--version" in sys.argv):
+        raise e
+
+if __name__ == "__main__":
+    setuptools.setup(**setup_args)


### PR DESCRIPTION
Hey @quigleyj97! Currently the only way to install `jupyterlab-spreadsheet` requires users to use `npm`, I have added the required setup files to create a `.whl` distribution of the package so users can use pypi (and `conda-forge`) to install this on their machines. This follows the "recommended" setup config from https://github.com/jupyterlab/extension-cookiecutter-ts/.

To test this locally you can try building it with the following set of command:
```
$ pip install build
$ python -m build -s     # builds the source package
$ python -m build          # builds the .whl
```
This will build `jupyterlab-spreadsheet/dist/jupyterlab_spreadsheet-0.4.1-py3-none-any.whl` and this can be installed with `pip`.

Happy to help with the pypi/conda-forge-feedstock setup to automate the builds and releases for this :)

Let me know!